### PR TITLE
Enable `ensemble_md` to work with `gmx_mpi`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,10 @@ jobs:
             cd $HOME && mkdir pkgs 
             git clone https://gitlab.com/gromacs/gromacs.git
             cd gromacs && mkdir build && cd build
-            cmake .. -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DCMAKE_INSTALL_PREFIX=$HOME/pkgs -DGMX_ENABLE_CCACHE=ON
+            cmake .. -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DCMAKE_INSTALL_PREFIX=$HOME/pkgs -DGMX_ENABLE_CCACHE=ON -DGMX_MPI=on
             make install 
             source $HOME/pkgs/bin/GMXRC
-            gmx --version
+            gmx_mpi --version
             ccache -s
 
       - run:

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -16,7 +16,7 @@ in the future when possible.
 ===============
 2.1. Requirements
 -----------------
-Before installing :code:`ensemble_md`, one should have working versions of `GROMACS`_. Please refer to the linked documentations for full installation instructions.
+Importantly, :code:`ensemble_md` only works with MPI-enabled `GROMACS`_. Please refer to the linked documentation for full installation instructions.
 All the other pip-installable dependencies of :code:`ensemble_md` (specified in :code:`setup.py` of the package)
 will be automatically installed during the installation of the package.
 

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -58,29 +58,21 @@ Here is the help message of :code:`run_EEXE`:
                             The maximum number of warnings in parameter specification to be
                             ignored.
 
+Same as any other replica-exchange methods, EEXE only works with MPI-enabled GROMACS. To leverage
+the allocated computational resources, one can specify the number of MPI processes via the parameter
+:code:`n_proc`, with the CLI of MPI (e.g. :code:`mpirun` or :code:`mpiexec`) speicifed via the 
+parameter :code:`mpi_cli`. In addition, one can specify the number of OpenMP threads per MPI process (i.e., 
+:code:`-ntomp` used with the GROMACS mdrun commands) via the parameter :code:`runtime_args` by using
+:code:`runtime_args = {'-ntomp': '16'}`. 
+
+
+
 In our current implementation, it is assumed that all replicas of an EEXE simulations are performed in
 parallel using MPI. Naturally, performing an EEXE simulation using :code:`run_EEXE` requires a command-line interface
 to launch MPI processes, such as :code:`mpirun` or :code:`mpiexec`. For example, to run an EEXE simulation
 composed of 4 replicas, one must use :code:`mpirun -np 4 run_EEXE` (or :code:`mpiexec -n 4 run_EEXE`),
 where the value of :code:`-np` should be the same as the number of replicas.
-
-Importantly, it is recommended that more details about resources allocated for 
-each replicas are excplitily specified in the input YAML file . As an example,
-here we consider a case of running an EEXE simulation composed of 4 replicas on a 128-core node.
-Since our implementation works for both tMPI-enabled and MPI-enabled GROMACS, one
-can do the following to make sure all cores are used:
-
-- If tMPI-enabled GROMACS is used, one can launch the simulation using :code:`mpirun -np 4 run_EEXE`,
-    with :code:`runtime_args = {'-nt': 32, 'ntmpi': 1}` specified in the input YAML file. Note that :code:`-nt`
-    should be 32 to use all the 128 CPU cores, while the value of :code:`ntmpi` can be numbers like 1, 2, 4, ..., etc.
-- If MPI-enabled GROMACS is used, one can launch the simulation using :code:`mpirun -np 4 run_EEXE`,
-    but with :code:`runtime_args = {'-np': 16, 'ntomp': 2}` specified in the input YAML file. Note that in this case,
-    there are two levels of parallelism. :code:`-np 4` in the command :code:`mpirun -np 4 run_EEXE` runs 4 instances
-    of the CLI :code:`run_EEXE`. Inside :code:`run_EEXE`, :code:`subprocess.run()` performes each of the 4 GROMACS :code:`mdrun`
-    commands in parallel, each with 16 MPI processes and 2 OpenMP threads per MPI process. That is, each replica
-    runs on :math:`16 \times 2=32` CPU cores, so all 4 replicas use 128 cores in total. Of course, different numbers of 
-    :code:`-np` and :code:`-ntomp` can be used as long as their produce is 32 in this case. For more information about
-    the parameter :code:`runtime_args` in the input YAML file, see :ref:`doc_EEXE_parameters`.
+For more information about the parameter :code:`runtime_args` in the input YAML file, see :ref:`doc_EEXE_parameters`.
 
 1.3. CLI :code:`analyze_EEXE`
 -----------------------------
@@ -323,9 +315,10 @@ include parameters for data analysis here.
 For convenience, here is a template of the input YAML file, with each optional parameter specified with the default and required 
 parameters left with a blank. Note that specifying :code:`null` is the same as leaving the parameter unspecified (i.e. :code:`None`).
 
-::
 
-    # Section 1: Executables
+.. code-block:: yaml
+
+    # Section 1: Runtime configuration
     gmx_executable:
     mpi_cli: 'mpirun'
     n_proc: null

--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -224,17 +224,20 @@ In the current implementation of the algorithm, 22 parameters can be specified i
 Note that the two CLIs :code:`run_EEXE` and :code:`analyze_EEXE` share the same input YAML file, so we also
 include parameters for data analysis here.
 
-3.1. Executables
-----------------
+3.1. Runtime configuration
+--------------------------
 
-  - :code:`gmx_executable`: (Required)
+  - :code:`gmx_executable`: (Optional, Default: :code:`gmx_mpi`)
       The GROMACS executable to be used to run the EEXE simulation. The value could be as simple as :code:`gmx`
-      or :code:`gmx_mpi` if the exeutable has be sourced. Otherwise, the full path of the exetuable (e.g.
-      :code:`/usr/local/gromacs/bin/gmx`, the path returned by the command :code:`which gmx`).
+      or :code:`gmx_mpi` if the exeutable has been sourced. Otherwise, the full path of the executable (e.g.
+      :code:`/usr/local/gromacs/bin/gmx`, the path returned by the command :code:`which gmx`) should be used.
+      Note that EEXE only works with MPI-enabled GROMACS. 
   - :code:`mpi_cli`: (Optional, Default: :code:`mpirun`)
       The CLI for launching MPI processes, e.g. :code:`mpirun` or :code:`mpiexec`. Note that this parameter
       is only required when MPI-enabled GROMACS is used. If tMPI-enabled GROMACS executable is specified 
       in :code:`gmx_executable`, the value of :code:`mpi_cli` will be ignored.
+  - :code:`n_proc`: (Optional, Default: the number of replicas, i.e. the value of :code:`n_sim`)
+      The number of MPI processes to run the EEXE simulation.
 
 3.2. Simulation inputs
 ----------------------
@@ -325,6 +328,7 @@ parameters left with a blank. Note that specifying :code:`null` is the same as l
     # Section 1: Executables
     gmx_executable:
     mpi_cli: 'mpirun'
+    n_proc: null
 
     # Section 2: Simulation inputs
     gro:

--- a/ensemble_md/analysis/analyze_matrix.py
+++ b/ensemble_md/analysis/analyze_matrix.py
@@ -33,11 +33,11 @@ def parse_transmtx(log_file, expanded_ensemble=True):
 
     Returns
     -------
-    empirical : numpy.ndarray
+    empirical : np.ndarray
         The final empirical state transition matrix.
-    theoretical : None or numpy.ndarray
+    theoretical : None or np.ndarray
         The final theoretical state transition matrix.
-    diff_matrix : None or numpy.ndarray
+    diff_matrix : None or np.ndarray
         The difference between the theortial and empirical state transition matrix (empirical - theoretical).
     """
     f = open(log_file, "r")
@@ -92,12 +92,12 @@ def calc_equil_prob(trans_mtx):
 
     Parameters
     ----------
-    trans_mtx : numpy.ndarray
+    trans_mtx : np.ndarray
         The input state transition matrix
 
     Returns
     -------
-    equil_prob : numpy.ndarray
+    equil_prob : np.ndarray
     """
     check_row = sum([np.isclose(np.sum(trans_mtx[i]), 1) for i in range(len(trans_mtx))])
     check_col = sum([np.isclose(np.sum(trans_mtx[:, i]), 1) for i in range(len(trans_mtx))])
@@ -128,7 +128,7 @@ def calc_spectral_gap(trans_mtx, atol=1e-8):
 
     Parameters
     ----------
-    trans_mtx : numpy.ndarray
+    trans_mtx : np.ndarray
         The input state transition matrix
     atol: float
         The absolute tolerance for checking the sum of columns and rows.
@@ -172,7 +172,7 @@ def split_transmtx(trans_mtx, n_sim, n_sub):
 
     Parameters
     ----------
-    trans_mtx : numpy.ndarray
+    trans_mtx : np.ndarray
         The input state transition matrix to split
     n_sim : int
         The number of replicas in EEXE.
@@ -202,7 +202,7 @@ def plot_matrix(matrix, png_name, title=None, start_idx=0):
 
     Parameters
     ----------
-    matrix : numpy.ndarray
+    matrix : np.ndarray
         The matrix to be visualized
     png_name : str
         The file name of the output PNG file (including the extension).

--- a/ensemble_md/analysis/analyze_matrix.py
+++ b/ensemble_md/analysis/analyze_matrix.py
@@ -122,7 +122,7 @@ def calc_equil_prob(trans_mtx):
     return equil_prob
 
 
-def calc_spectral_gap(trans_mtx):
+def calc_spectral_gap(trans_mtx, atol=1e-8):
     """
     Calculates the spectral gap of the input transition matrix.
 
@@ -130,6 +130,8 @@ def calc_spectral_gap(trans_mtx):
     ----------
     trans_mtx : numpy.ndarray
         The input state transition matrix
+    atol: float
+        The absolute tolerance for checking the sum of columns and rows.
 
     Returns
     -------
@@ -138,8 +140,8 @@ def calc_spectral_gap(trans_mtx):
     eig_vals : list
         The list of eigenvalues
     """
-    check_row = sum([np.isclose(np.sum(trans_mtx[i]), 1) for i in range(len(trans_mtx))])
-    check_col = sum([np.isclose(np.sum(trans_mtx[:, i]), 1) for i in range(len(trans_mtx))])
+    check_row = sum([np.isclose(np.sum(trans_mtx[i]), 1, atol=atol) for i in range(len(trans_mtx))])
+    check_col = sum([np.isclose(np.sum(trans_mtx[:, i]), 1, atol=atol) for i in range(len(trans_mtx))])
 
     if check_row == len(trans_mtx):
         eig_vals, eig_vecs = np.linalg.eig(trans_mtx.T)

--- a/ensemble_md/analysis/analyze_traj.py
+++ b/ensemble_md/analysis/analyze_traj.py
@@ -462,9 +462,8 @@ def plot_transit_time(trajs, N, fig_prefix=None, dt=None, folder='.'):
             plt.figure()
             for i in range(len(t_list)):    # t_list[i] is the list for configuration i
                 plt.plot(np.arange(len(t_list[i])) + 1, t_list[i], label=f'Configuration {i}', marker=marker)
-            if np.array(t_list).shape != (1, 0):  # at least one configuration has at least one event
-                if np.max(np.max((t_list))) >= 10000:
-                    plt.ticklabel_format(style='sci', axis='y', scilimits=(0, 0))
+            if np.max(np.max((t_list))) >= 10000:
+                plt.ticklabel_format(style='sci', axis='y', scilimits=(0, 0))
             plt.xlabel('Event index')
             plt.ylabel(f'{y_labels[t]}')
             plt.grid()

--- a/ensemble_md/analysis/analyze_traj.py
+++ b/ensemble_md/analysis/analyze_traj.py
@@ -128,7 +128,7 @@ def traj2transmtx(traj, N, normalize=True):
 
     Returns
     -------
-    transmtx : numpy.ndarray
+    transmtx : np.ndarray
         The transition matrix computed from the trajectory
     """
     transmtx = np.zeros([N, N])

--- a/ensemble_md/analysis/msm_analysis.py
+++ b/ensemble_md/analysis/msm_analysis.py
@@ -64,7 +64,7 @@ def plot_its(trajs, lags, fig_name, dt=1, units='step'):
     Returns
     -------
     ts_list : list
-        An list of instances of the ImpliedTimescales class in PyEMMA.
+        An list of instances of the :code:`ImpliedTimescales` class in PyEMMA.
     """
     ts_list = []
     n_rows, n_cols = utils.get_subplot_dimension(len(trajs))

--- a/ensemble_md/cli/analyze_EEXE.py
+++ b/ensemble_md/cli/analyze_EEXE.py
@@ -172,10 +172,12 @@ def main():
 
     # 2-4. For each configurration, calculate the spectral gap of the overall transition matrix obtained in step 2-2.
     print('\n2-4. Calculating the spectral gap of the state transition matrices ...')
-    spectral_gaps, eig_vals = [analyze_matrix.calc_spectral_gap(mtx) for mtx in mtx_list]
+    results = [analyze_matrix.calc_spectral_gap(mtx) for mtx in mtx_list]  # a list of tuples
+    spectral_gaps = [results[i][0] for i in range(len(results))]
+    eig_vals = [results[i][1] for i in range(len(results))]
     if None not in spectral_gaps:
         for i in range(EEXE.n_sim):
-            print(f'   - Configuration {i}: {spectral_gaps[i]:.3f} (λ_1: {eig_vals[0]:.5f}, λ_2: {eig_vals[1]:.5f})')
+            print(f'   - Configuration {i}: {spectral_gaps[i]:.3f} (λ_1: {eig_vals[i][0]:.5f}, λ_2: {eig_vals[i][1]:.5f})')
         print(f'   - Average of the above: {np.mean(spectral_gaps):.3f} (std: {np.std(spectral_gaps, ddof=1):.3f})')
 
     # 2-5. For each configuration, calculate the stationary distribution from the overall transition matrix obtained in step 2-2.  # noqa: E501

--- a/ensemble_md/cli/analyze_EEXE.py
+++ b/ensemble_md/cli/analyze_EEXE.py
@@ -177,7 +177,7 @@ def main():
     eig_vals = [results[i][1] for i in range(len(results))]
     if None not in spectral_gaps:
         for i in range(EEXE.n_sim):
-            print(f'   - Configuration {i}: {spectral_gaps[i]:.3f} (λ_1: {eig_vals[i][0]:.5f}, λ_2: {eig_vals[i][1]:.5f})')
+            print(f'   - Configuration {i}: {spectral_gaps[i]:.3f} (λ_1: {eig_vals[i][0]:.5f}, λ_2: {eig_vals[i][1]:.5f})')  # noqa: E501
         print(f'   - Average of the above: {np.mean(spectral_gaps):.3f} (std: {np.std(spectral_gaps, ddof=1):.3f})')
 
     # 2-5. For each configuration, calculate the stationary distribution from the overall transition matrix obtained in step 2-2.  # noqa: E501

--- a/ensemble_md/cli/run_EEXE.py
+++ b/ensemble_md/cli/run_EEXE.py
@@ -14,7 +14,6 @@ import copy
 import shutil
 import argparse
 import numpy as np
-from mpi4py import MPI
 from datetime import datetime
 
 from ensemble_md.utils import utils
@@ -65,137 +64,121 @@ def main():
     sys.stdout = utils.Logger(logfile=args.output)
     sys.stderr = utils.Logger(logfile=args.output)
 
-    # Step 1: Set up MPI rank and instantiate EnsembleEXE to set up EEXE parameters
-    comm = MPI.COMM_WORLD
-    rank = comm.Get_rank()  # Note that this is a GLOBAL variable
-
-    if rank == 0:
-        print(f'Current time: {datetime.now().strftime("%d/%m/%Y %H:%M:%S")}')
-        print(f'Command line: {" ".join(sys.argv)}\n')
+# Step 1: Instantiate EnsembleEXE to set up EEXE parameters
+    print(f'Current time: {datetime.now().strftime("%d/%m/%Y %H:%M:%S")}')
+    print(f'Command line: {" ".join(sys.argv)}\n')
 
     EEXE = EnsembleEXE(args.yaml)
 
-    if rank == 0:
-        # Print out simulation parameters
-        EEXE.print_params()
+    # Print out simulation parameters
+    EEXE.print_params()
 
-        # Print out warnings and fail if needed
-        for i in EEXE.warnings:
-            print(f'\n{i}\n')
+    # Print out warnings and fail if needed
+    for i in EEXE.warnings:
+        print(f'\n{i}\n')
 
-        if len(EEXE.warnings) > args.maxwarn:
-            raise ParameterError(
-                f"The execution failed due to warning(s) about parameter spcificaiton. Check the warnings, or consider setting maxwarn in the input YAML file if you find them harmless.")  # noqa: E501, F541
+    if len(EEXE.warnings) > args.maxwarn:
+        raise ParameterError(
+            f"The execution failed due to warning(s) about parameter spcificaiton. Check the warnings, or consider setting maxwarn in the input YAML file if you find them harmless.")  # noqa: E501, F541
 
     # Step 2: If there is no checkpoint file found/provided, perform the 1st iteration (index 0)
     if os.path.isfile(args.ckpt) is False:
         start_idx = 1
 
-        # 2-1. Set up input files for all simulations with 1 rank
-        if rank == 0:
-            for i in range(EEXE.n_sim):
-                os.mkdir(f'sim_{i}')
-                os.mkdir(f'sim_{i}/iteration_0')
-                MDP = EEXE.initialize_MDP(i)
-                MDP.write(f"sim_{i}/iteration_0/{EEXE.mdp.split('/')[-1]}", skipempty=True)
+        # 2-1. Set up input files for all simulations
+        for i in range(EEXE.n_sim):
+            os.mkdir(f'sim_{i}')
+            os.mkdir(f'sim_{i}/iteration_0')
+            MDP = EEXE.initialize_MDP(i)
+            MDP.write(f"sim_{i}/iteration_0/{EEXE.mdp.split('/')[-1]}", skipempty=True)
 
         # 2-2. Run the first ensemble of simulations
         EEXE.run_EEXE(0)
 
     else:
-        if rank == 0:
-            # If there is a checkpoint file, we see the execution as an extension of an EEXE simulation
-            ckpt_data = np.load(args.ckpt)
-            start_idx = len(ckpt_data[0])  # The length should be the same for the same axis
-            print(f'\nGetting prepared to extend the EEXE simulation from iteration {start_idx} ...')
+        # If there is a checkpoint file, we see the execution as an extension of an EEXE simulation
+        ckpt_data = np.load(args.ckpt)
+        start_idx = len(ckpt_data[0])  # The length should be the same for the same axis
+        print(f'\nGetting prepared to extend the EEXE simulation from iteration {start_idx} ...')
 
-            if start_idx == EEXE.n_iter:
-                print('Extension aborted: The expected number of iterations have been completed!')
-                sys.exit()
-            else:
-                print('Deleting data generated after the checkpoint ...')
-                for i in range(EEXE.n_sim):
-                    n_finished = len(next(os.walk(f'sim_{i}'))[1])  # number of finished iterations
-                    for j in range(start_idx, n_finished):
-                        print(f'  Deleting the folder sim_{i}/iteration_{j}')
-                        shutil.rmtree(f'sim_{i}/iteration_{j}')
-
-            # Read g_vecs.npy and rep_trajs.npy so that new data can be appended, if any.
-            # Note that these two arrays are created in rank 0 and should always be operated in rank 0,
-            # or broadcasting is required.
-            EEXE.rep_trajs = [list(i) for i in ckpt_data]
-            if os.path.isfile(args.g_vecs) is True:
-                EEXE.g_vecs = [list(i) for i in np.load(args.g_vecs)]
+        if start_idx == EEXE.n_iter:
+            print('Extension aborted: The expected number of iterations have been completed!')
+            sys.exit()
         else:
-            start_idx = None
+            print('Deleting data generated after the checkpoint ...')
+            for i in range(EEXE.n_sim):
+                n_finished = len(next(os.walk(f'sim_{i}'))[1])  # number of finished iterations
+                for j in range(start_idx, n_finished):
+                    print(f'  Deleting the folder sim_{i}/iteration_{j}')
+                    shutil.rmtree(f'sim_{i}/iteration_{j}')
 
-        start_idx = comm.bcast(start_idx, root=0)  # so that all the ranks are aware of start_idx
+        # Read g_vecs.npy and rep_trajs.npy so that new data can be appended, if any.
+        EEXE.rep_trajs = [list(i) for i in ckpt_data]
+        if os.path.isfile(args.g_vecs) is True:
+            EEXE.g_vecs = [list(i) for i in np.load(args.g_vecs)]
 
     for i in range(start_idx, EEXE.n_iter):
-        if rank == 0:
-            # Step 3: Swap the coordinates
-            # 3-1. For all the replica simulations,
-            #   (1) Find the last sampled state and the corresponding lambda values from the DHDL files.
-            #   (2) Find the final Wang-Landau incrementors and weights from the LOG files.
-            dhdl_files = [f'sim_{j}/iteration_{i - 1}/dhdl.xvg' for j in range(EEXE.n_sim)]
-            log_files = [f'sim_{j}/iteration_{i - 1}/md.log' for j in range(EEXE.n_sim)]
-            states_ = EEXE.extract_final_dhdl_info(dhdl_files)
-            wl_delta, weights_, counts = EEXE.extract_final_log_info(log_files)
-            print()
+        # Step 3: Swap the coordinates
+        # 3-1. For all the replica simulations,
+        #   (1) Find the last sampled state and the corresponding lambda values from the DHDL files.
+        #   (2) Find the final Wang-Landau incrementors and weights from the LOG files.
+        dhdl_files = [f'sim_{j}/iteration_{i - 1}/dhdl.xvg' for j in range(EEXE.n_sim)]
+        log_files = [f'sim_{j}/iteration_{i - 1}/md.log' for j in range(EEXE.n_sim)]
+        states_ = EEXE.extract_final_dhdl_info(dhdl_files)
+        wl_delta, weights_, counts = EEXE.extract_final_log_info(log_files)
+        print()
 
-            # 3-2. Identify swappable pairs, propose swap(s), calculate P_acc, and accept/reject swap(s)
-            # Note after `get_swapping_pattern`, `states_` and `weights_` won't be necessarily
-            # since they are updated by `get_swapping_pattern`. (Even if the function does not explicitly
-            # returns `states_` and `weights_`, `states_` and `weights_` can still be different after
-            # the use of the function.) Therefore, here we create copyes for `states_` and `weights_`
-            # before the use of `get_swapping_pattern`, so we can use them in `histogram_correction`,
-            # `combine_weights` and `update_MDP`.
-            states = copy.deepcopy(states_)
-            weights = copy.deepcopy(weights_)
-            swap_pattern = EEXE.get_swapping_pattern(dhdl_files, states_, weights_)
+        # 3-2. Identify swappable pairs, propose swap(s), calculate P_acc, and accept/reject swap(s)
+        # Note after `get_swapping_pattern`, `states_` and `weights_` won't be necessarily
+        # since they are updated by `get_swapping_pattern`. (Even if the function does not explicitly
+        # returns `states_` and `weights_`, `states_` and `weights_` can still be different after
+        # the use of the function.) Therefore, here we create copyes for `states_` and `weights_`
+        # before the use of `get_swapping_pattern`, so we can use them in `histogram_correction`,
+        # `combine_weights` and `update_MDP`.
+        states = copy.deepcopy(states_)
+        weights = copy.deepcopy(weights_)
+        swap_pattern = EEXE.get_swapping_pattern(dhdl_files, states_, weights_)
 
-            # 3-3. Calculate the weights averaged since the last update of the Wang-Landau incrementor.
-            # Note that the averaged weights are used for histogram correction/weight combination.
-            # For the calculation of the acceptance ratio (inside get_swapping_pattern), final weights should be used.
-            if EEXE.N_cutoff != -1 or EEXE.w_combine is True:
-                # Only when histogram correction/weight combination is needed.
-                weights_avg, weights_err = EEXE.get_averaged_weights(log_files)
+        # 3-3. Calculate the weights averaged since the last update of the Wang-Landau incrementor.
+        # Note that the averaged weights are used for histogram correction/weight combination.
+        # For the calculation of the acceptance ratio (inside get_swapping_pattern), final weights should be used.
+        if EEXE.N_cutoff != -1 or EEXE.w_combine is True:
+            # Only when histogram correction/weight combination is needed.
+            weights_avg, weights_err = EEXE.get_averaged_weights(log_files)
 
-            # 3-4. Perform histogram correction/weight combination
-            # Note that we never use final weights but averaged weights here.
-            # The product of this step should always be named as "weights" to be used in update_MDP
-            if wl_delta != [None for i in range(EEXE.n_sim)]:  # weight-updating
-                print(f'\nCurrent Wang-Landau incrementors: {wl_delta}')
-            if EEXE.N_cutoff != -1 and EEXE.w_combine is True:
-                # perform both
-                weights_avg = EEXE.histogram_correction(weights_avg, counts)
-                weights, g_vec = EEXE.combine_weights(weights_avg)
-                EEXE.g_vecs.append(g_vec)
-            elif EEXE.N_cutoff == -1 and EEXE.w_combine is True:
-                # only perform weight combination
-                print('\nNote: No histogram correction will be performed.')
-                weights, g_vec = EEXE.combine_weights(weights_avg)
-                EEXE.g_vecs.append(g_vec)
-            elif EEXE.N_cutoff != -1 and EEXE.w_combine is False:
-                # only perform histogram correction
-                print('\nNote: No weight combination will be performed.')
-                weights = EEXE.histogram_correction(weights_avg, counts)
-            else:
-                print('\nNote: No histogram correction will be performed.')
-                print('Note: No weight combination will be performed.')
-
-            # 3-5. Modify the MDP files and swap out the GRO files (if needed)
-            # Here we keep the lambda range set in mdp the same across different iterations in the same folder but swap out the gro file  # noqa: E501
-            # Note we use states (copy of states_) instead of states_ in update_MDP.
-            for j in list(range(EEXE.n_sim)):
-                os.mkdir(f'sim_{j}/iteration_{i}')
-                MDP = EEXE.update_MDP(f"sim_{j}/iteration_{i - 1}/{EEXE.mdp.split('/')[-1]}", j, i, states, wl_delta, weights, counts)   # modify with a new template  # noqa: E501
-                MDP.write(f"sim_{j}/iteration_{i}/{EEXE.mdp.split('/')[-1]}", skipempty=True)
-                # In run_EEXE(i, swap_pattern), where the tpr files will be generated, we use the top file at the
-                # level of the simulation (the file that will be shared by all simulations). For the gro file, we pass
-                # swap_pattern to the function to figure it out internally.
+        # 3-4. Perform histogram correction/weight combination
+        # Note that we never use final weights but averaged weights here.
+        # The product of this step should always be named as "weights" to be used in update_MDP
+        if wl_delta != [None for i in range(EEXE.n_sim)]:  # weight-updating
+            print(f'\nCurrent Wang-Landau incrementors: {wl_delta}')
+        if EEXE.N_cutoff != -1 and EEXE.w_combine is True:
+            # perform both
+            weights_avg = EEXE.histogram_correction(weights_avg, counts)
+            weights, g_vec = EEXE.combine_weights(weights_avg)
+            EEXE.g_vecs.append(g_vec)
+        elif EEXE.N_cutoff == -1 and EEXE.w_combine is True:
+            # only perform weight combination
+            print('\nNote: No histogram correction will be performed.')
+            weights, g_vec = EEXE.combine_weights(weights_avg)
+            EEXE.g_vecs.append(g_vec)
+        elif EEXE.N_cutoff != -1 and EEXE.w_combine is False:
+            # only perform histogram correction
+            print('\nNote: No weight combination will be performed.')
+            weights = EEXE.histogram_correction(weights_avg, counts)
         else:
-            swap_pattern = None
+            print('\nNote: No histogram correction will be performed.')
+            print('Note: No weight combination will be performed.')
+
+        # 3-5. Modify the MDP files and swap out the GRO files (if needed)
+        # Here we keep the lambda range set in mdp the same across different iterations in the same folder but swap out the gro file  # noqa: E501
+        # Note we use states (copy of states_) instead of states_ in update_MDP.
+        for j in list(range(EEXE.n_sim)):
+            os.mkdir(f'sim_{j}/iteration_{i}')
+            MDP = EEXE.update_MDP(f"sim_{j}/iteration_{i - 1}/{EEXE.mdp.split('/')[-1]}", j, i, states, wl_delta, weights, counts)   # modify with a new template  # noqa: E501
+            MDP.write(f"sim_{j}/iteration_{i}/{EEXE.mdp.split('/')[-1]}", skipempty=True)
+            # In run_EEXE(i, swap_pattern), where the tpr files will be generated, we use the top file at the
+            # level of the simulation (the file that will be shared by all simulations). For the gro file, we pass
+            # swap_pattern to the function to figure it out internally.
 
         if -1 not in EEXE.equil and 0 not in EEXE.equil:
             # This is the case where the weights are equilibrated in a weight-updating simulation.
@@ -206,47 +189,43 @@ def main():
 
         # Step 4: Perform another iteration
         # 4-1. Run another ensemble of simulations
-        swap_pattern = comm.bcast(swap_pattern, root=0)
         EEXE.run_EEXE(i, swap_pattern)
 
-        if rank == 0:
-            # 4-2. Save data
-            if (i + 1) % EEXE.n_ckpt == 0:
-                if len(EEXE.g_vecs) != 0:
-                    # Save g_vec as a function of time if weight combination was used.
-                    np.save('g_vecs.npy', EEXE.g_vecs)
+        # 4-2. Save data
+        if (i + 1) % EEXE.n_ckpt == 0:
+            if len(EEXE.g_vecs) != 0:
+                # Save g_vec as a function of time if weight combination was used.
+                np.save('g_vecs.npy', EEXE.g_vecs)
 
-                print('\n----- Saving .npy files to checkpoint the simulation ---')
-                np.save('rep_trajs.npy', EEXE.rep_trajs)
+            print('\n----- Saving .npy files to checkpoint the simulation ---')
+            np.save('rep_trajs.npy', EEXE.rep_trajs)
 
     # Save the npy files at the end of the simulation anyway.
-    if rank == 0:
-        if len(EEXE.g_vecs) != 0:  # The length will be 0 only if there is no weight combination.
-            np.save('g_vecs.npy', EEXE.g_vecs)
-        np.save('rep_trajs.npy', EEXE.rep_trajs)
+    if len(EEXE.g_vecs) != 0:  # The length will be 0 only if there is no weight combination.
+        np.save('g_vecs.npy', EEXE.g_vecs)
+    np.save('rep_trajs.npy', EEXE.rep_trajs)
 
     # Step 5: Write a summary for the simulation ensemble
-    if rank == 0:
-        print('\nSummary of the simulation ensemble')
-        print('==================================')
-        print('Simulation status:')
-        for i in range(EEXE.n_sim):
-            if EEXE.fixed_weights is True:
-                print(f'- Rep {i}: The weights were fixed throughout the simulation.')
-            elif EEXE.equil[i] == -1:
-                print(f'  - Rep {i}: The weights have not been equilibrated.')
+    print('\nSummary of the simulation ensemble')
+    print('==================================')
+    print('Simulation status:')
+    for i in range(EEXE.n_sim):
+        if EEXE.fixed_weights is True:
+            print(f'- Rep {i}: The weights were fixed throughout the simulation.')
+        elif EEXE.equil[i] == -1:
+            print(f'  - Rep {i}: The weights have not been equilibrated.')
+        else:
+            idx = int(np.floor(EEXE.equil[i] / (EEXE.dt * EEXE.nst_sim)))
+            if EEXE.equil[i] > 1000:
+                units = 'ns'
+                EEXE.equil[i] /= 1000
             else:
-                idx = int(np.floor(EEXE.equil[i] / (EEXE.dt * EEXE.nst_sim)))
-                if EEXE.equil[i] > 1000:
-                    units = 'ns'
-                    EEXE.equil[i] /= 1000
-                else:
-                    units = 'ps'
-                print(f'  - Rep {i}: The weights have been equilibrated at {EEXE.equil[i]:.2f} {units} (iteration {idx}).')  # noqa: E501
+                units = 'ps'
+            print(f'  - Rep {i}: The weights have been equilibrated at {EEXE.equil[i]:.2f} {units} (iteration {idx}).')  # noqa: E501
 
-        print(f'\n{EEXE.n_empty_swappable} out of {EEXE.n_iter}, or {EEXE.n_empty_swappable / EEXE.n_iter * 100:.1f}% iterations had an empty list of swappable pairs.')  # noqa: E501
-        print(f'{EEXE.n_rejected} out of {EEXE.n_swap_attempts}, or {EEXE.n_rejected / EEXE.n_swap_attempts * 100:.1f}% of attempted exchanges were rejected.')  # noqa: E501
+    print(f'\n{EEXE.n_empty_swappable} out of {EEXE.n_iter}, or {EEXE.n_empty_swappable / EEXE.n_iter * 100:.1f}% iterations had an empty list of swappable pairs.')  # noqa: E501
+    print(f'{EEXE.n_rejected} out of {EEXE.n_swap_attempts}, or {EEXE.n_rejected / EEXE.n_swap_attempts * 100:.1f}% of attempted exchanges were rejected.')  # noqa: E501
 
-        print(f'\nTime elapsed: {utils.format_time(time.time() - t1)}')
+    print(f'\nTime elapsed: {utils.format_time(time.time() - t1)}')
 
     sys.exit()

--- a/ensemble_md/ensemble_EXE.py
+++ b/ensemble_md/ensemble_EXE.py
@@ -456,14 +456,13 @@ class EnsembleEXE:
         odict = OrderedDict([(k.replace('-', '_'), v) for k, v in params.items()])
         params_new = gmx_parser.MDP(None, **odict)
 
-        if rank == 0:
-            if params_new.keys() == params.keys():
-                self.reformatted_mdp = False  # no need to reformat the file
-            else:
-                self.reformatted_mdp = True
-                new_name = self.mdp.split('.mdp')[0] + '_backup.mdp'
-                shutil.move(self.mdp, new_name)
-                params_new.write(self.mdp)
+        if params_new.keys() == params.keys():
+            self.reformatted_mdp = False  # no need to reformat the file
+        else:
+            self.reformatted_mdp = True
+            new_name = self.mdp.split('.mdp')[0] + '_backup.mdp'
+            shutil.move(self.mdp, new_name)
+            params_new.write(self.mdp)
 
     def map_lambda2state(self):
         """

--- a/ensemble_md/tests/data/expanded.mdp
+++ b/ensemble_md/tests/data/expanded.mdp
@@ -11,7 +11,7 @@ nstfout = 0
 nstlog = 100
 nstcalcenergy = 1
 nstenergy = 1000
-nstxout_compressed = 1000
+nstxout_compressed = 100
 
 ; Neighborsearching and short-range nonbonded interactions
 nstlist = 10

--- a/ensemble_md/tests/test_ensemble_EXE.py
+++ b/ensemble_md/tests/test_ensemble_EXE.py
@@ -32,7 +32,7 @@ def params_dict():
     Generates a dictionary containing the required EEXE parameters.
     """
     EEXE_dict = {
-        'gmx_executable': 'gmx',
+        'gmx_executable': 'gmx_mpi',
         'gro': 'ensemble_md/tests/data/sys.gro',
         'top': 'ensemble_md/tests/data/sys.top',
         'mdp': 'ensemble_md/tests/data/expanded.mdp',
@@ -161,7 +161,7 @@ class Test_EnsembleEXE:
         EEXE = get_EEXE_instance(params_dict)
 
         # 1. Check the required EEXE parameters
-        assert EEXE.gmx_executable == 'gmx'
+        assert EEXE.gmx_executable == 'gmx_mpi'
         assert EEXE.gro == "ensemble_md/tests/data/sys.gro"
         assert EEXE.top == "ensemble_md/tests/data/sys.top"
         assert EEXE.mdp == "ensemble_md/tests/data/expanded.mdp"
@@ -187,7 +187,6 @@ class Test_EnsembleEXE:
         assert EEXE.seed is None
 
         # 3. Check the MDP parameters
-        assert EEXE.nsteps == 500
         assert EEXE.dt == 0.002
         assert EEXE.temp == 298
         assert EEXE.nst_sim == 500

--- a/ensemble_md/utils/gmx_parser.py
+++ b/ensemble_md/utils/gmx_parser.py
@@ -155,9 +155,9 @@ def parse_log(log_file):
                 equil_step = int(l.split(":")[0].split("Step")[1])
                 equil_time = equil_step * dt + tinit  # ps
                 if wl_delta is not None and wl_delta < cutoff:
-                    # This should only happen when equil_time % nstlog == 0, where the weights should have been appended
-                    # Note that we additionally have wl_delta is not None. Since wl_delta could be None if the weights get equilibrated
-                    # right after the simulation stop (before nstlog).
+                    # Should only happen when equil_time % nstlog == 0, where the weights should have been appended
+                    # Note that we additionally have wl_delta is not None. Since wl_delta could be None if the
+                    # weights get equilibrated right after the simulation stop (before nstlog).
                     append_equil = True
 
             wl_delta = wl_delta_list[-1]

--- a/ensemble_md/utils/gmx_parser.py
+++ b/ensemble_md/utils/gmx_parser.py
@@ -154,8 +154,10 @@ def parse_log(log_file):
                 find_equil = True  # After this, we will append weights one last time, which are equilibrated weights.
                 equil_step = int(l.split(":")[0].split("Step")[1])
                 equil_time = equil_step * dt + tinit  # ps
-                if wl_delta < cutoff:
-                    # Should only happen when equil_time % nstlog == 0, where the weights should have been appended
+                if wl_delta is not None and wl_delta < cutoff:
+                    # This should only happen when equil_time % nstlog == 0, where the weights should have been appended
+                    # Note that we additionally have wl_delta is not None. Since wl_delta could be None if the weights get equilibrated
+                    # right after the simulation stop (before nstlog).
                     append_equil = True
 
             wl_delta = wl_delta_list[-1]

--- a/ensemble_md/utils/utils.py
+++ b/ensemble_md/utils/utils.py
@@ -171,7 +171,7 @@ def get_subplot_dimension(n_panels):
 def weighted_mean(vals, errs):
     """
     Calculates the inverse-variance-weighted mean. Note that if
-    any error is 0, the simple mean will be returned. 
+    any error is 0, the simple mean will be returned.
 
     Parameters
     ----------


### PR DESCRIPTION
The goal of this PR is to allow running EEXE simulations using MPI-enabled GROMACS. Here are some notes and thoughts relevant to this goal. Note that we refer to the original implementation as the commit 4ffb70a0021b8940aa0a24de46d7963af34fe4d3, which is the commit right before this PR (i.e. right before the branch is created).

## 1. The use of mpi4py in the original implementation of EEXE
Here we summarize the purposes of using `mpi4py` in `ensemble_EXE.py` for the original implementation.
- In the original implementation, `mpi4py` is imported in `ensemble_EXE.py` using `from mpi4py import MPI`. Then, global variables `comm` and `rank` are created by `comm = MPI.COMM_WORLD` and `rank = comm.Get_rank()` so that tasks can be assigned to different ranks. Specifically, most operations in `ensemble_EXE.py` only use one rank, which is assigned to rank 0 using a conditional statement (`if rank == 0:`). The only operations performed in parallel are the executions of GROMACS `grompp` and `mdrun` commands, which are done by launching subprocess calls under the conditional statement `if rank < self.n_sim:`. 
- Notably, the original implementation only works for GROMACS with thread-MPI, not for MPI-enabled GROMACS. That is, the subprocess calls do not call `mpirun` or `mpiexec`. In fact, as discussed in the next section, calling `mpirun` or `mpiexec` using `subprocess.run` in a code that imports `mpi4py` could cause issues. 

## 2. The issue of nested MPI calls
To enable MPI-enabled GROMACS in the original implementation of EEXE, the most straightforward approach is probably simply calling MPI-enabled GROMACS  (with `mpiexec` or `mpirun`) using `subprocess.run`. This approach was attempted in the commit d2953ef656f52a427458e0e6f086506e197117d2 (the first commit below). However, this did not work for the original implementation (commit 4ffb70a0021b8940aa0a24de46d7963af34fe4d3), which imported `mpi4py` using `from mpi4py import MPI`. To better understand this, here is an example (`code.py`) demonstrating the issue of calling `mpirun` using `subprocess.run` while `mpi4py` is imported in the code:
```
import subprocess
from mpi4py import MPI
subprocess.run(['mpiexec', '-n', '1', 'ls'], capture_output=True, text=True, check=True)
```
Upon execution of `python code.py`, the following error would occur:
```
Traceback (most recent call last):
  File "/Users/Wei-TseHsu/Documents/Life_in_CU_Bouler/Research_in_Shirts_Lab/EEXE_experiments/Preliminary_tests/anthracene/test/code.py", line 3, in <module>
  subprocess.run(['mpiexec', '-n', '1', 'ls'], capture_output=True, text=True, check=True)
  File "/usr/local/Cellar/python@3.9/3.9.15/Frameworks/Python.framework/Versions/3.9/lib/python3.9/subprocess.py", line 528, in run
  raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['mpiexec', '-n', '1', 'ls']' returned non-zero exit status 1.
```
On the other hand, with `from mpi4py import MPI` removed from the code, the code should work fine with `python code.py`. This is because that the `mpi4py` library, when imported, automatically initializes MPI using `MPI_Init()`, i.e., creates an MPI environment. Specifically, when `subprocess.run(['mpiexec', '-n', '1', '/usr/local/bin/gmx', '-version']` is called, the code would try to start another MPI environment within the one that has already been started by mpi4py (i.e. nested MPI calls), which would cause an error like the one shown above, even if the command intended to be executed by `mpiexec` would not incur an error. (The error comes from calling `mpiexec` in an MPI environment.)

Here is a relevant discussion about nested MPI calls, though it doesn't seem able to solve our issue here: https://stackoverflow.com/questions/39617250/nesting-mpi-calls-with-mpi4py

## 3. Possible workarounds
In this section, we discussed different possible workarounds tried for the issue. 
### 3.1. Delay MPI initialization
Specifically, the code above would work if modified as below, which delays the initialization of MPI:
```
import subprocess
from mpi4py import rc

rc.initialize = False  # Delay MPI initialization

from mpi4py import MPI

subprocess.run(['mpiexec', '-n', '1', 'ls'], capture_output=True, text=True, check=True)

if not MPI.Is_initialized():
    MPI.Init()  # Initialize MPI when you actually need it
```
This workaround proposes using the same logic for the EEXE implementation. However, it was later found that this did not work, since we still need the variable `rank` to be able to run GROMACS commands in parallel using `mpi4py`, but MPI must be initialized to use `rank`. Also, once MPI is initialized, it cannot be "de-initialized" but can only be finalized (e.g. using `MPI.Finalize()`). Toggling on and off MPI using `MPI.Init()` and `MPI.Finalize` would not make sense since this is not MPI is intended for and this approach would just be awkward. 

### 3.2. Spawn a new process using `MPI.COMM_SELF.Spawn`
Specifically, the following code is considered in this workaround, which assumes GROMACS to be MPI-compatible:
```
from mpi4py import MPI
comm = MPI.COMM_SELF.Spawn('/usr/local/bin/gmx', args=['-version'], maxprocs=1)
```
Notably, `MPI.COMM_SELF.Spawn` starts an MPI subprocess, creating a separate intercommunication. This workaround proposes spawning new processes in the EEXE implementation. However, this workaround was again, later found not working in our implementation since the execution of the code would just hang there without crashing with any error. This is likely because the command (`gmx -version`) is not an MPI-aware operation. Since we will still need to run GROMACS commands not designed to be parallelized (e.g. the `grompp` command), this process is still not suitable for our purpose. 

### 3-3. Discard the use of `mpi4py` and launch GROMACS simulations with the flag `-multidir`
As discussed in the first section, we needed `mpi4py` to 
  - Run GROMACS `grompp` commands in parallel
  - Run GROAMCS `mdrun` commands in parallel

In our case, different replicas of simulations in EEXE are performed in different folders in parallel. This can actually be done using the `-multidir` flag with the GROMACS `mdrun` command, as documented [here](https://manual.gromacs.org/current/user-guide/mdrun-features.html#running-multi-simulations). Therefore, one possible workaround is to use `-multidir` to replace the use of `mpi4py`, and perform GROMACS `grompp` commands serially, which hopefully would not introduce too much overhead compared to running GROMACS `grompp` commands in parallel. (There might be other possible ways to run `grompp` commands in parallel without using `mpi4py`, but we will explore that later anyway.) Specifically, this workaround proposes using subprocess calls to run only one GROMACS `mdrun` command (instead of `n`, where `n` is the number of replicas) to run multiple simulations in parallel and launch GROMACS `grompp` commands (using subprocesses) serially.

Notably, the flag `-multidir` is only available in MPI-enabled GROMACS, so in this workaround, the new implementation of EEXE will be restricted to only working with MPI-enabled GROMACS. (Note that it seems impossible to allow the use of both thread-MPI GROMACS and MPI-enabled GROMACS, since we need mpi4py for thread-MPI GROMACS parallelization, but that would lead to nested MPI calls if MPI-enabled GROMACS is used, which always fail subprocess calls. As such, we need to disable the use of thread-MPI GROMACS in the new implementation of EEXE.) However, this is a reasonable/natural choice, since methods based on replica exchange do not work with thread-MPI GROMACS anyway, and EEXE is intended to be highly parallelized for complex systems. 

## 4. Outcome
Workaround 3-3 (mainly implemented in commits 77415b64b794269ca16f6efb5952d706741d45cf) successfully enabled MPI-enabled GROMACS in the new implementation of EEXE and disabled the use of thread-MPI GROMACS. 

## 5. Checklist

- [x] Implement necessary algorithms to enable MPI-enabled GROMACS.
- [x] Update the unit tests and pass CI.
- [x] Update the documentation to reflect the changes.