### PR TITLE
Refactor weight combination schemes

### DIFF
--- a/docs/simulations.rst
+++ b/docs/simulations.rst
@@ -277,34 +277,21 @@ include parameters for data analysis here.
       This could be useful for REXEE simulations for multiple serial mutations, where we enforce exchanges between states 4 and 5 (and 14 and 15) and perform
       coordinate manipulation.
   - :code:`proposal`: (Optional, Default: :code:`exhaustive`)
-      The method for proposing simulations to be swapped. Available options include :code:`single`, :code:`exhaustive`, :code:`neighboring`, and :code:`multiple`.
+      The method for proposing simulations to be swapped. Available options include :code:`single`, :code:`neighboring`, and :code:`exhaustive`.
       For more details, please refer to :ref:`doc_proposal`.
   - :code:`acceptance`: (Optional, Default: :code:`metropolis`)
       The Monte Carlo method for swapping simulations. Available options include :code:`same-state`/:code:`same_state`, :code:`metropolis`, and :code:`metropolis-eq`/:code:`metropolis_eq`. 
       For more details, please refer to :ref:`doc_acceptance`.
-  - :code:`w_combine`: (Optional, Default: :code:`None`)
-      The type of weights to be combined across multiple replicas in a weight-updating REXEE simulation. The following options are available:
-
-        - :code:`None`: No weight combination.
-        - :code:`final`: Combine the final weights.
-        - :code:`avg`: Combine the weights averaged over from last time the Wang-Landau incrementor was updated.
- 
-      For more details about weight combination, please refer to :ref:`doc_w_schemes`.
-  
-  - :code:`rmse_cutoff`: (Optional, Default: :code:`None`)
-      The cutoff for the root-mean-square error (RMSE) between the weights of the current iteration 
-      and the weights averaged over from the last time the Wang-Landau incrementor was updated.
-      For each replica, the RMSE between the averaged weights and the current weights will be calculated.
-      When :code:`rmse_cutoff` is specified, weight combination will be performed only if the maximum RMSE across all replicas
-      is smaller than the cutoff. Otherwise, weight combination is deactivated (even if :code:`w_combine` is specified)
-      because a larger RMSE indicates that the weights are noisy and should not be combined.
-      The default value is infinity, which means that weight combination will always be performed if :code:`w_combine` is specified.
-      The units of the cutoff are :math:`k_B T`.
+  - :code:`w_combine`: (Optional, Default: :code:`False`)
+      Whether to perform weight combination or not. Note that weights averaged over from the last time the Wang-Landau incrementor was updated (instead of 
+      final weights) will be used for weight combination. For more details about weight combination, please refer to :ref:`doc_w_schemes`.
+  - :code:`w_mean_type`: (Optional, Default: code:`simple`)
+      The type of mean to use when combining weights. Available options include :code:`simple` and :code:`weighted`.
+      For the later case, inverse-variance weighted means are used. 
   - :code:`N_cutoff`: (Optional, Default: 1000)
-      The histogram cutoff. -1 means that no histogram correction will be performed.
-  - :code:`n_ex`: (Optional, Default: 1)
-      The number of attempts swap during an exchange interval. This option is only relevant if the option :code:`proposal` is :code:`multiple`.
-      Otherwise, this option is ignored. For more details, please refer to :ref:`doc_multiple_swaps`.
+      The histogram cutoff for weight corrections. -1 means that no histogram correction will be performed.
+  - :code:`hist_corr` (Optional, Default: :code:`False`)
+      Whether to perform histogram correction. 
   - :code:`mdp_args`: (Optional, Default: :code:`None`)
       MDP parameters differing across replicas provided in a dictionary. For each key in the dictionary, the value should
       always be a list of length of the number of replicas. For example, :code:`{'ref_p': [1.0, 1.01, 1.02, 1.03]}` means that the
@@ -389,10 +376,10 @@ infinity internally.
     add_swappables: null
     proposal: 'exhaustive'
     acceptance: 'metropolis' 
-    w_combine: null
-    rmse_cutoff: null
+    w_combine: False
+    w_mean_type: 'simple'
     N_cutoff: 1000
-    n_ex: 1
+    hist_corr: False
     mdp_args: null
     grompp_args: null
     runtime_args: null

--- a/docs/theory.rst
+++ b/docs/theory.rst
@@ -1,6 +1,8 @@
 .. _doc_basic_idea:
 
-.. note:: This page is still a work in progress. Please refer to our paper for more details before this page is completed.
+.. note:: This page is still a work in progress. Please check `Issue 33`_ for the current progress.
+
+.. _`Issue 33`: https://github.com/wehs7661/ensemble_md/issues/33
 
 1. Basic idea
 =============

--- a/ensemble_md/cli/run_REXEE.py
+++ b/ensemble_md/cli/run_REXEE.py
@@ -186,8 +186,16 @@ def main():
                         print('Performing weight combination ...')
                     else:
                         print('Performing weight combination ...', end='')
-                    counts, weights, g_vec = REXEE.combine_weights(counts_, weights_preprocessed)  # inverse-variance weighting seems worse  # noqa: E501
+                    weights, g_vec = REXEE.combine_weights(weights_preprocessed)  # inverse-variance weighting seems worse  # noqa: E501
                     REXEE.g_vecs.append(g_vec)
+
+                    # Check if histogram correction is needed after weight combination
+                    if REXEE.hist_corr is True:
+                        print('Performing histogram correction ...')
+                        counts = REXEE.histogram_correction(counts_)
+                    else:
+                        print('Note: No histogram correction will be performed.')
+
                 elif REXEE.N_cutoff == -1 and REXEE.w_combine is True:
                     # Only perform weight combination
                     print('Note: No weight correction will be performed.')
@@ -195,18 +203,26 @@ def main():
                         print('Performing weight combination ...')
                     else:
                         print('Performing weight combination ...', end='')
-                    counts, weights, g_vec = REXEE.combine_weights(counts_, weights_avg)
+                    weights, g_vec = REXEE.combine_weights(weights_avg)
                     REXEE.g_vecs.append(g_vec)
+
+                    # Check if histogram correction is needed after weight combination
+                    if REXEE.hist_corr is True:
+                        print('Performing histogram correction ...')
+                        counts = REXEE.histogram_correction(counts_)
+                    else:
+                        print('Note: No histogram correction will be performed.')
+
                 elif REXEE.N_cutoff != -1 and REXEE.w_combine is False:
                     # Only perform weight correction
                     print('Note: No weight combination will be performed.')
                     weights = REXEE.weights_correction(weights_avg, counts)
-                    _ = REXEE.combine_weights(counts_, weights, print_values=False)[1]  # just to print the combined weights  # noqa: E501
+                    _ = REXEE.combine_weights(weights, print_values=False)[1]  # just to print the combined weights  # noqa: E501
                 else:
                     print('Note: No weight correction will be performed.')
                     print('Note: No weight combination will be performed.')
                     # Note that in this case, the final weights will be used in the next iteration.
-                    _ = REXEE.combine_weights(counts_, weights, print_values=False)[1]  # just to print the combiend weights  # noqa: E501
+                    _ = REXEE.combine_weights(weights, print_values=False)[1]  # just to print the combiend weights  # noqa: E501
 
                 # 3-5. Modify the MDP files and swap out the GRO files (if needed)
                 # Here we keep the lambda range set in mdp the same across different iterations in the same folder but swap out the gro file  # noqa: E501

--- a/ensemble_md/cli/run_REXEE.py
+++ b/ensemble_md/cli/run_REXEE.py
@@ -186,12 +186,17 @@ def main():
                     else:
                         print('Performing weight correction ...', end='')
                     weights_preprocessed = REXEE.weight_correction(weights_avg, counts)
-                    
+
                     if REXEE.verbose is True:
                         print('Performing weight combination ...')
                     else:
                         print('Performing weight combination ...', end='')
-                    weights, g_vec = REXEE.combine_weights(weights_preprocessed)  # inverse-variance weighting seems worse  # noqa: E501
+                    if REXEE.w_mean_type == 'simple':
+                        weights, g_vec = REXEE.combine_weights(weights_preprocessed)  # simple means
+                    else:
+                        # Note that here weights_err are acutally not the uncertainties for weights_prepocessed
+                        # but weights_avg ... We might need to disable this feature in the future.
+                        weights, g_vec = REXEE.combine_weights(weights_preprocessed, weights_err)  # inverse-variance weighting  # noqa: E501
                     REXEE.g_vecs.append(g_vec)
 
                     # Check if histogram correction is needed after weight combination
@@ -208,7 +213,10 @@ def main():
                         print('Performing weight combination ...')
                     else:
                         print('Performing weight combination ...', end='')
-                    weights, g_vec = REXEE.combine_weights(weights_avg)
+                    if REXEE.w_mean_type == 'simple':
+                        weights, g_vec = REXEE.combine_weights(weights_avg)  # simple means
+                    else:
+                        weights, g_vec = REXEE.combine_weights(weights_avg, weights_err)  # inverse-variance weighting
                     REXEE.g_vecs.append(g_vec)
 
                     # Check if histogram correction is needed after weight combination

--- a/ensemble_md/cli/run_REXEE.py
+++ b/ensemble_md/cli/run_REXEE.py
@@ -181,7 +181,12 @@ def main():
                 # The product of this step should always be named as "weights" to be used in update_MDP
                 if REXEE.N_cutoff != -1 and REXEE.w_combine is True:
                     # Perform both weight correction and weight combination
+                    if REXEE.verbose is True:
+                        print('Performing weight correction ...')
+                    else:
+                        print('Performing weight correction ...', end='')
                     weights_preprocessed = REXEE.weight_correction(weights_avg, counts)
+                    
                     if REXEE.verbose is True:
                         print('Performing weight combination ...')
                     else:
@@ -216,6 +221,10 @@ def main():
                 elif REXEE.N_cutoff != -1 and REXEE.w_combine is False:
                     # Only perform weight correction
                     print('Note: No weight combination will be performed.')
+                    if REXEE.verbose is True:
+                        print('Performing weight correction ...')
+                    else:
+                        print('Performing weight correction ...', end='')
                     weights = REXEE.weights_correction(weights_avg, counts)
                     _ = REXEE.combine_weights(weights, print_values=False)[1]  # just to print the combined weights  # noqa: E501
                 else:

--- a/ensemble_md/replica_exchange_EE.py
+++ b/ensemble_md/replica_exchange_EE.py
@@ -876,7 +876,7 @@ class ReplicaExchangeEE:
         shifts = list(self.s * np.arange(self.n_sim))
         swap_pattern = list(range(self.n_sim))   # Can be regarded as the indices of DHDL files/configurations
         state_ranges = copy.deepcopy(self.state_ranges)
-        states_copy = copy.deepcopy(states)  # only for re-identifying swappable pairs given updated state_ranges
+        # states_copy = copy.deepcopy(states)  # only for re-identifying swappable pairs given updated state_ranges --> was needed for the multiple exchange proposal scheme  # noqa: E501
         swappables = ReplicaExchangeEE.identify_swappable_pairs(states, state_ranges, self.proposal == 'neighboring', self.add_swappables)  # noqa: E501
 
         # Note that if there is only 1 swappable pair, then it will still be the only swappable pair
@@ -1198,13 +1198,13 @@ class ReplicaExchangeEE:
         N_ratio_vec.insert(0, hist[0][0])
 
         # (3) Check if the histogram counts are 0 for some states, if so, the histogram correction will be skipped.
-        # Zero histogram counts can happen when the sampling is poor or the WL incrementor just got updated 
+        # Zero histogram counts can happen when the sampling is poor or the WL incrementor just got updated
         contains_nan = any(np.isnan(value) for sublist in N_ratio_adjacent for value in sublist)  # can be caused by 0/0  # noqa: E501
         contains_inf = any(np.isinf(value) for sublist in N_ratio_adjacent for value in sublist)  # can be caused by x/0, where x is a finite number  # noqa: E501
         skip_hist_correction = contains_nan or contains_inf
         if skip_hist_correction:
             print('\n  Histogram correction is skipped because the histogram counts are 0 for some states.')
-        
+
         # (4) Perform histogram correction if it is not skipped
         if skip_hist_correction is False:
             print('\n  Performing histogram correction ...')
@@ -1261,7 +1261,7 @@ class ReplicaExchangeEE:
         # (2) Calculate adjacent weight differences and g_vec
         dg_vec = []  # alchemical weight differences for the whole range
         dg_adjacent = [list(np.diff(weights[i])) for i in range(len(weights))]
-        
+
         if weights_err is not None:
             dg_adjacent_err = [[np.sqrt(weights_err[i][j] ** 2 + weights_err[i][j + 1] ** 2) for j in range(len(weights_err[i]) - 1)] for i in range(len(weights_err))]  # noqa: E501
 
@@ -1280,7 +1280,7 @@ class ReplicaExchangeEE:
 
         dg_vec.insert(0, 0)
         g_vec = np.array([sum(dg_vec[:(i + 1)]) for i in range(len(dg_vec))])
-        
+
         # (3) Determine the vector of alchemical weights for each replica
         weights_modified = np.zeros_like(weights)
         for i in range(self.n_sim):

--- a/ensemble_md/replica_exchange_EE.py
+++ b/ensemble_md/replica_exchange_EE.py
@@ -163,6 +163,7 @@ class ReplicaExchangeEE:
             "proposal": 'exhaustive',
             "acceptance": "metropolis",
             "w_combine": False,
+            "w_mean_type": 'simple',
             "N_cutoff": 1000,
             "hist_corr": False,
             "verbose": True,
@@ -1134,11 +1135,7 @@ class ReplicaExchangeEE:
         weights : list
             An updated list of lists of corected weights.
         """
-        if self.verbose is True:
-            print("\nPerforming weight correction for the lambda weights ...")
-        else:
-            print("\nPerforming weight correction for the lambda weights ...", end="")
-
+        skip_correction = False
         for i in range(len(weights)):  # loop over the replicas
             if self.verbose is True:
                 print(f"  Counts of rep {i}:\t\t{counts[i]}")
@@ -1148,8 +1145,11 @@ class ReplicaExchangeEE:
                 if counts[i][j - 1] != 0 and counts[i][j - 1] != 0:
                     if np.min([counts[i][j - 1], counts[i][j]]) > self.N_cutoff:
                         weights[i][j] += np.log(counts[i][j - 1] / counts[i][j])
+                    else:
+                        skip_correction = True
+                        print('Weight correction was deactivated because neither N_{k-1} or N_k is larger than the histogram cutoff.')  # noqa: E501
 
-            if self.verbose is True:
+            if self.verbose is True and skip_correction is False:
                 print(f'  Corrected weights of rep {i}:\t{[float(f"{k:.3f}") for k in weights[i]]}\n')
 
         if self.verbose is False:

--- a/ensemble_md/replica_exchange_EE.py
+++ b/ensemble_md/replica_exchange_EE.py
@@ -493,7 +493,9 @@ class ReplicaExchangeEE:
         print(f"Proposal scheme: {self.proposal}")
         print(f"Acceptance scheme for swapping simulations: {self.acceptance}")
         print(f"Whether to perform weight combination: {self.w_combine}")
-        print(f"Histogram cutoff: {self.N_cutoff}")
+        print(f"Type of means for weight combination: {self.w_mean_type}")
+        print(f"Whether to perform histogram correction: {self.hist_corr}")
+        print(f"Histogram cutoff for weight correction: {self.N_cutoff}")
         print(f"Number of replicas: {self.n_sim}")
         print(f"Number of iterations: {self.n_iter}")
         print(f"Length of each replica: {self.dt * self.nst_sim} ps")
@@ -1179,8 +1181,8 @@ class ReplicaExchangeEE:
         # (1) Print the original histogram counts
         if print_values is True:
             print('  Original histogram counts:')
-            for i in range(len(self.hist)):
-                print(f'    Rep {i}: {self.hist[i]}')
+            for i in range(len(hist)):
+                print(f'    Rep {i}: {hist[i]}')
 
         # (2) Calculate adjacent weight differences and g_vec
         N_ratio_vec = []  # N_{k-1}/N_k for the whole range

--- a/ensemble_md/replica_exchange_EE.py
+++ b/ensemble_md/replica_exchange_EE.py
@@ -1149,35 +1149,6 @@ class ReplicaExchangeEE:
 
         return weights_avg, weights_err
 
-    def prepare_weights(self, weights_avg, weights_final):
-        """
-        Prepared weights to be combined by the function :code:`combine_weights`.
-
-        Parameters
-        ----------
-        weights_avg : list
-            A list of lists of weights averaged since the last update of the Wang-Landau
-            incrementor. The length of the list should be the number of replicas.
-        weights_final : list
-            A list of lists of final weights of all simulations. The length of the list should
-            be the number of replicas.
-
-        Returns
-        -------
-        weights_output : list
-            A list of lists of weights to be combined.
-        """
-        rmse_list = [utils.calc_rmse(weights_avg[i], weights_final[i]) for i in range(self.n_sim)]
-        rmse_str = ', '.join([f'{i:.2f}' for i in rmse_list])
-        print(f'RMSE between the final weights and time-averaged weights for each replica: {rmse_str} kT')
-
-        if self.w_combine is True:
-            weights_output = weights_avg
-        else:
-            weights_output = None
-
-        return weights_output
-
     def combine_weights(self, hist, weights, weights_err=None, print_values=True):
         """
         Combine alchemical weights across multiple replicas and adjusts the histogram counts


### PR DESCRIPTION
# Checklist
This PR aims to not only address issue #29 but also include some additional tasks. Here is the checklist:
- [x] Removing the functionality relevant to `rmse_cutoff`
- [x] Removing the option `final` from the YAML parameter `w_combine`
    - [x] Turning the YAML parameter `w_combine` into a boolean
    - [x] Removing the function `prepare_weights`
- [x] Deprecating the schemes of multiple swaps. 
- [x] Provide a YAML parameter `w_mean_type` to specify using simple means or weighted means in weight combination
- [x] Compartmentalize the histogram correction method
- [x] Update the documentation
- [x] Update the unit tests

# Some justifications
Generally, the idea is to simplify the options available in REXEE simulations, especially for those related to weight combinations. Since the weight combination does not seem to bring advantages, we plan to keep the most basic functionalities for demonstration purposes in the paper. 

## 1. Removing the functionality relevant to `rmse_cutoff`
Preliminary data have shown that weight combination does not accelerate weight convergence in weight-updating simulations in most cases. Using `rmse_cutoff` was shown to alleviate the issue, but that is merely reflecting the fact that the combination is performed less frequently. Therefore, we decided to remove the YAML parameter `rmse_cutoff` and the relevant functionalities. 

## 2. Removing the option `final` from the YAML parameter `w_combine`
The final weights are known to be noisy compared to the time-averaged weights and should never be used for weight combinations. Therefore, we decide to remove the option `final` from the choices of the YAML parameter `w_combine`. This would lead to only two options for `w_combine`, including `None` and `avg`. Therefore, we turned the parameter `w_combine` into a boolean - whenever weight combination is activated, we always use time-averaged weights. Additionally, we will need to remove the function `prepare_weights`.

## 3. Deprecating multiple exchange proposal scheme
As discussed in the paper, the multiple exchange proposal scheme does not have symmetric proposal probabilities, while the derivation of the acceptance ratio assumes symmetric proposal probabilities, which are much more common in replica exchange methods. That is, using the multiple exchange proposal scheme with the acceptance ratio derived in the paper would lead to a violation of the detailed balance. As such, we decided to deprecate the codes implementing the multiple exchange proposal scheme by commenting out the code. Note that we do not remove the codes completely as the detailed balance might still be obeyed if the acceptance ratio is carefully designed to accommodate the asymmetry of the proposal probabilities of the multiple exchange proposal scheme. Still, this is outside the scope of our paper, so the option will be made unavailable in the package. To do this, the following is required:
- Deprecate the YAML parameter `n_ex`. 
- Deprecate the option `multiple` from the YAML parameter `proposal`.

## 4. Provide a YAML parameter to specify using simple means or weighted means in weight combination.
Currently, the implementation only uses inverse-variance weight means in weight combinations, but both options should be available as the inverse-variance weighted means do not always perform better than simple means. 

## 5. Compartmentalize the histogram correction method
Currently, the histogram correction method is implemented in `combine_weights` and is always applied after weight combination. We decided to compartmentalize the histogram correction method and let users decide whether to perform histogram correction by specifying the new YAML parameter that we are also adding here, `hist_corr`. 

